### PR TITLE
Set ignition_on from vehicle status if engine key exists in vehicle status.

### DIFF
--- a/py_uconnect/client.py
+++ b/py_uconnect/client.py
@@ -310,6 +310,9 @@ class Client:
                         s, "CLOSED", "windows", "passenger", "status"
                     )
 
+                if "engine" in s:
+                    vehicle.ignition_on = sg_eq(s, "ON", "engine", "status")
+
                 vehicle.trunk_locked = sg_eq(s, "LOCKED", "trunk", "status")
                 vehicle.ev_running = sg_eq(s, "ON", "evRunning", "status")
 


### PR DESCRIPTION
Hello,

For some cars (like Jeep Wrangler 2024), the engine status (ignition) does not exist in evInfo (which I'm guessing is for EV cars only), and is instead returned in `api.get_vehicle_status()` like so,

> {'doors': {'rightRear': {'status': 'LOCKED'}, 'driver': {'status': 'LOCKED'}, 'passenger': {'status': 'LOCKED'}, 'leftRear': {'status': 'LOCKED'}}, 'trunk': {'status': 'LOCKED'}, **'engine': {'status': 'OFF'}**, 'timestamp': 1743970840410}

The engine status changes to 'ON' when the vehicle engine turns on and 'OFF' when it is off. This commit sets  `vehicle.ignition_on` properly for these cars.

In my commit, I set `vehicle.ignition_on` to `status.engine` if the engine key exists overriding any previous value, however I do not consider the scenario where both `evInfo.ignitionStatus` and `status.engine` are set and what happens if they differ. If you have any suggestion on how you want that handled, I can make the changes to the commit. 

Thanks!