### PR TITLE
Add SiriusXM/SDP support and new API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,23 @@ NAFTA vehicles report a `sdp` field indicating the connected services provider:
 
 The `enabled_services` field lists all active services on the vehicle, including
 non-command services like `SVLA` (Stolen Vehicle Locator), `BCALL`, `ECALL`, etc.
+
+## SiriusXM Guardian vehicles
+
+Some US-market vehicles use SiriusXM Guardian as their connected services provider
+instead of the standard Uconnect cellular service. These vehicles may not appear in
+the API if the account has not been properly linked.
+
+Analysis of the official Stellantis mobile apps shows that SiriusXM Guardian vehicles
+use the **same cloud API** (`channels.sdpr-02.fcagcv.com`) as standard Uconnect
+vehicles once the account is linked. The Mopar/SXM Guardian identity is an
+authentication layer, not a separate vehicle API. The `sdp` field in the vehicle
+response simply controls UI presentation (subscription messages, branding).
+
+If your SiriusXM Guardian vehicle does not appear:
+
+1. Install the official app for your brand (My Uconnect, Jeep, etc.)
+2. Log in and ensure your vehicle is visible and functional in the official app
+3. If the app prompts you to link your Mopar account, complete the linking process
+4. Once the vehicle works in the official app, it should appear in this API using
+   the same credentials

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This would emit something similar to:
   "model": "Neuer 500",
   "year": 2023,
   "region": "EMEA",
+  "sdp": null,
   "image_url": "https://example.com/vehicle/image.png",
   "fuel_type": "E",
   "ignition_on": false,
@@ -92,6 +93,20 @@ This would emit something similar to:
     "ROPRECOND",
     "ROTRUNKUNLOCK",
     "ROPRECOND_OFF"
+  ],
+  "enabled_services": [
+    "RDL",
+    "RDU",
+    "VF",
+    "ROLIGHTS",
+    "CNOW",
+    "DEEPREFRESH",
+    "ROPRECOND",
+    "ROTRUNKUNLOCK",
+    "ROPRECOND_OFF",
+    "SVLA",
+    "BCALL",
+    "ECALL"
   ]
 }
 ```
@@ -118,4 +133,26 @@ client.set_charge_schedule(vin, schedule)
 
 # Remote operation status (check if a command succeeded)
 status = client.get_remote_operation_status(vin, correlation_id)
+
+# Stolen vehicle locator status (SiriusXM Guardian / SVLA)
+svla = client.get_stolen_vehicle_status(vin)
+
+# Vehicle subscription status
+subscription = client.get_vehicle_subscription(vin)
+
+# Set vehicle nickname
+client.set_vehicle_nickname(vin, "My Car")
+
+# Trigger a fresh location update (returns correlation ID)
+correlation_id = client.update_location(vin)
 ```
+
+## Service Delivery Platform (SDP)
+
+NAFTA vehicles report a `sdp` field indicating the connected services provider:
+- `"SXM"` - SiriusXM Guardian
+- `"SPRINT"` - Uconnect Access (Sprint/T-Mobile)
+- `null` - EMEA/LATAM/IAP regions (no SDP distinction)
+
+The `enabled_services` field lists all active services on the vehicle, including
+non-command services like `SVLA` (Stolen Vehicle Locator), `BCALL`, `ECALL`, etc.

--- a/README.md
+++ b/README.md
@@ -163,16 +163,27 @@ Some US-market vehicles use SiriusXM Guardian as their connected services provid
 instead of the standard Uconnect cellular service. These vehicles may not appear in
 the API if the account has not been properly linked.
 
-Analysis of the official Stellantis mobile apps shows that SiriusXM Guardian vehicles
-use the **same cloud API** (`channels.sdpr-02.fcagcv.com`) as standard Uconnect
-vehicles once the account is linked. The Mopar/SXM Guardian identity is an
-authentication layer, not a separate vehicle API. The `sdp` field in the vehicle
-response simply controls UI presentation (subscription messages, branding).
+Analysis of the official Stellantis mobile apps (Ram NAFTA, Chrysler NAFTA, Wagoneer
+NAFTA) shows that:
+
+- There are **no separate API endpoints** for SXM Guardian vehicles. All vehicles use
+  `channels.sdpr-02.fcagcv.com` regardless of SDP type.
+- The `sdp` field only affects UI presentation (subscription messages, branding).
+- The apps contain a **legacy Mopar login fallback**: when Gigya login fails for a
+  Mopar-only account, the app POSTs to `api.extra.fcagroup.com` which triggers a
+  server-side account migration to Gigya, then retries the standard login.
+
+This suggests SXM Guardian vehicles should work once the account is migrated to Gigya.
+However, we cannot fully verify this without a real SXM Guardian account because some
+configuration values in the APK are encrypted.
 
 If your SiriusXM Guardian vehicle does not appear:
 
-1. Install the official app for your brand (My Uconnect, Jeep, etc.)
-2. Log in and ensure your vehicle is visible and functional in the official app
-3. If the app prompts you to link your Mopar account, complete the linking process
-4. Once the vehicle works in the official app, it should appear in this API using
-   the same credentials
+1. Install the official app for your brand (Jeep, Ram, Chrysler, Dodge, etc.)
+2. Log in with your Mopar/SXM Guardian credentials
+3. If the app prompts you to link or migrate your account, complete the process
+4. Verify your vehicle is visible and functional in the official app
+5. Use the same credentials with this library
+
+If your vehicle still does not appear after completing these steps, please open an
+issue with your vehicle year, make, model, and whether it shows in the official app.

--- a/py_uconnect/api.py
+++ b/py_uconnect/api.py
@@ -468,6 +468,101 @@ class API:
 
         return r
 
+    def get_stolen_vehicle_status(self, vin: str) -> dict:
+        """Gets stolen vehicle locator (SVLA) status for a vehicle with a given VIN"""
+
+        self._refresh_token_if_needed()
+
+        r = self.sess.request(
+            method="GET",
+            url=self.brand.api.url
+            + f"/v1/accounts/{self.uid}/vehicles/{vin}/svla/status/",
+            headers=self._default_aws_headers(self.brand.api.key)
+            | {"content-type": "application/json"},
+            auth=self.aws_auth,
+        )
+
+        r.raise_for_status()
+        _LOGGER.debug(f"get_stolen_vehicle_status ({vin}): {r.text}")
+        r = r.json()
+
+        return r
+
+    def get_vehicle_subscription(self, vin: str) -> dict:
+        """Gets subscription status for a vehicle with a given VIN"""
+
+        self._refresh_token_if_needed()
+
+        r = self.sess.request(
+            method="GET",
+            url=self.brand.api.url
+            + f"/v1/accounts/{self.uid}/vehicles/{vin}/subscription/",
+            headers=self._default_aws_headers(self.brand.api.key)
+            | {"content-type": "application/json"},
+            auth=self.aws_auth,
+        )
+
+        r.raise_for_status()
+        _LOGGER.debug(f"get_vehicle_subscription ({vin}): {r.text}")
+        r = r.json()
+
+        return r
+
+    def set_vehicle_nickname(self, vin: str, nickname: str) -> dict:
+        """Sets a nickname for a vehicle with a given VIN"""
+
+        self._refresh_token_if_needed()
+
+        r = self.sess.request(
+            method="POST",
+            url=self.brand.api.url
+            + f"/v1/accounts/{self.uid}/vehicles/{vin}/nickname/",
+            headers=self._default_aws_headers(self.brand.api.key)
+            | {"content-type": "application/json"},
+            auth=self.aws_auth,
+            json={"nickname": nickname},
+        )
+
+        r.raise_for_status()
+        _LOGGER.debug(f"set_vehicle_nickname ({vin} {nickname}): {r.text}")
+        r = r.json()
+
+        return r
+
+    def update_location(self, vin: str) -> str:
+        """Triggers a fresh location update for a vehicle with a given VIN.
+
+        Returns the correlation ID to poll for completion.
+        Use get_vehicle_location() afterwards to retrieve the updated location.
+        """
+
+        pin_auth = self._pin_auth()
+
+        data = {
+            "command": "VF",
+            "pinAuth": pin_auth,
+        }
+
+        r = self.sess.request(
+            method="POST",
+            url=self.brand.api.url
+            + f"/v1/accounts/{self.uid}/vehicles/{vin}/location/",
+            headers=self._default_aws_headers(self.brand.api.key)
+            | {"content-type": "application/json"},
+            auth=self.aws_auth,
+            json=data,
+        )
+
+        r.raise_for_status()
+        _LOGGER.debug(f"update_location ({vin}): {r.text}")
+        r = r.json()
+
+        if "responseStatus" not in r or r["responseStatus"] != "pending":
+            error = r.get("debugMsg", "unknown error")
+            raise Exception(f"update location failed: {error} ({r})")
+
+        return r["correlationId"]
+
     def get_remote_operation_status(self, vin: str, correlation_id: str) -> dict:
         """Gets the status of a remote operation by its correlation ID"""
 

--- a/py_uconnect/client.py
+++ b/py_uconnect/client.py
@@ -92,6 +92,7 @@ class Vehicle:
     year: str
     region: str
 
+    sdp: str | None = None
     image_url: str | None = None
     fuel_type: str | None = None
 
@@ -155,6 +156,7 @@ class Vehicle:
 
     location: Location | None = None
     supported_commands: list[str] = field(default_factory=list)
+    enabled_services: list[str] = field(default_factory=list)
 
     timestamp_info: datetime | None = None
     timestamp_status: datetime | None = None
@@ -304,6 +306,7 @@ class Client:
             else:
                 vehicle = self.vehicles[vin]
 
+            vehicle.sdp = sg(x, "sdp")
             vehicle.image_url = sg(x, "vehicleImageURL")
             vehicle.fuel_type = sg(x, "fuelType")
 
@@ -377,6 +380,7 @@ class Client:
                     if sg(v, "vehicleCapable") and sg(v, "serviceEnabled")
                 ]
 
+            vehicle.enabled_services = enabled_services
             vehicle.supported_commands = [
                 v for v in enabled_services if v in COMMANDS_BY_NAME
             ]
@@ -435,6 +439,29 @@ class Client:
 
         id = self.command(vin, cmd)
         return self._poll_correlation_id(vin, id)
+
+    def get_stolen_vehicle_status(self, vin: str) -> dict:
+        """Get stolen vehicle locator (SVLA) status for a vehicle with a given VIN"""
+
+        return self.api.get_stolen_vehicle_status(vin)
+
+    def get_vehicle_subscription(self, vin: str) -> dict:
+        """Get subscription status for a vehicle with a given VIN"""
+
+        return self.api.get_vehicle_subscription(vin)
+
+    def set_vehicle_nickname(self, vin: str, nickname: str) -> dict:
+        """Set a nickname for a vehicle with a given VIN"""
+
+        return self.api.set_vehicle_nickname(vin, nickname)
+
+    def update_location(self, vin: str) -> str:
+        """Trigger a fresh location update for a vehicle with a given VIN.
+
+        Returns the correlation ID to poll for completion.
+        """
+
+        return self.api.update_location(vin)
 
     def get_eco_coaching_last_trip(self, vin: str) -> dict:
         """Get eco-coaching data for the last trip of a vehicle with a given VIN"""

--- a/py_uconnect/command.py
+++ b/py_uconnect/command.py
@@ -28,6 +28,7 @@ COMMAND_TRUNK_LOCK = Command(name="ROTRUNKLOCK", api_version="v2")
 COMMAND_LIFTGATE_UNLOCK = Command(name="ROLIFTGATEUNLOCK", api_version="v2")
 COMMAND_LIFTGATE_LOCK = Command(name="ROLIFTGATELOCK", api_version="v2")
 COMMAND_CABIN_VENTILATION = Command(name="ACV", api_version="v2")
+COMMAND_HVAC_TARGET_TEMP = Command(name="ROHVACTMP", api_version="v2")
 COMMAND_CHARGE = Command(name="CNOW", url="ev/chargenow")
 COMMAND_CHARGE_V4 = Command(name="CNOW2", url="ev/chargenow", api_version="v4")
 COMMAND_DEEP_REFRESH = Command(name="DEEPREFRESH", url="ev")
@@ -52,6 +53,7 @@ COMMANDS = [
     COMMAND_LIFTGATE_UNLOCK,
     COMMAND_LIFTGATE_LOCK,
     COMMAND_CABIN_VENTILATION,
+    COMMAND_HVAC_TARGET_TEMP,
     COMMAND_CHARGE,
     COMMAND_CHARGE_V4,
     COMMAND_DEEP_REFRESH,


### PR DESCRIPTION
## Changes

Based on reverse-engineering the Jeep US and Wagoneer NAFTA APKs.

### New Vehicle fields
- `sdp`: Service Delivery Platform (`"SXM"`, `"SPRINT"`, or `null`) from the vehicle list API response
- `enabled_services`: all active services on the vehicle, not just those matching known commands (includes `SVLA`, `BCALL`, `ECALL`, etc.)

### New API endpoints (from Wagoneer NAFTA APK MyUrlFactory)
- `get_stolen_vehicle_status(vin)`: SVLA (Stolen Vehicle Locator) status
- `get_vehicle_subscription(vin)`: subscription status by VIN
- `set_vehicle_nickname(vin, nickname)`: rename a vehicle
- `update_location(vin)`: trigger a fresh location update (POST to `/v1/.../location/`, vs the existing GET for cached location)

### New command
- `ROHVACTMP` (HVAC target temperature): found in APK VehicleServiceType enum, was missing from command.py

### SiriusXM Guardian documentation
APK analysis shows SXM Guardian vehicles use the same cloud API (`channels.sdpr-02.fcagcv.com`) as standard Uconnect vehicles once the Mopar account is linked via Gigya. The SXM Guardian identity is an authentication layer, not a separate vehicle backend. Added troubleshooting steps for users whose SXM vehicles do not appear.