### PR TITLE
fix: EV command 403s with v2/v4 fallbacks

### DIFF
--- a/py_uconnect/api.py
+++ b/py_uconnect/api.py
@@ -609,14 +609,7 @@ class API:
 
         return r["token"]
 
-    def command(self, vin: str, cmd: Command):
-        """Sends given command to the vehicle with a given VIN"""
-
-        if self.dev_mode:
-            return
-
-        pin_auth = self._pin_auth()
-
+    def _command_with_pin_auth(self, vin: str, cmd: Command, pin_auth: str):
         data = {
             "command": cmd.name,
             "pinAuth": pin_auth,
@@ -641,6 +634,33 @@ class API:
             raise Exception(f"command queuing failed: {error} ({r})")
 
         return r["correlationId"]
+
+    def command(self, vin: str, cmd: Command):
+        """Sends given command to the vehicle with a given VIN"""
+
+        if self.dev_mode:
+            return
+
+        pin_auth = self._pin_auth()
+
+        try:
+            return self._command_with_pin_auth(vin, cmd, pin_auth)
+        except requests.exceptions.HTTPError as err:
+            fallback = getattr(cmd, "fallback", None)
+
+            if (
+                err.response is not None
+                and err.response.status_code == 403
+                and fallback is not None
+            ):
+                _LOGGER.warning(
+                    "%s command returned 403; retrying with %s",
+                    cmd,
+                    fallback,
+                )
+                return self._command_with_pin_auth(vin, fallback, pin_auth)
+
+            raise
 
     def get_charge_schedules(self, vin: str) -> dict:
         """Gets EV charge schedules for a vehicle with a given VIN"""

--- a/py_uconnect/client.py
+++ b/py_uconnect/client.py
@@ -431,7 +431,7 @@ class Client:
                     if result in ("failure", "failed", "error", "rejected"):
                         return False
 
-            except Exception as err:
+            except (ConnectionError, TimeoutError, ValueError) as err:
                 last_error = err
 
             r = self._get_commands_statuses(vin)

--- a/py_uconnect/client.py
+++ b/py_uconnect/client.py
@@ -412,13 +412,36 @@ class Client:
         interval: timedelta = timedelta(seconds=2),
     ) -> bool:
         start = datetime.now()
+        last_error: Exception | None = None
+
         while datetime.now() - start < timeout:
             sleep(interval.seconds)
+
+            try:
+                status = self.get_remote_operation_status(vin, id)
+
+                result = sg(status, "status") or sg(status, "responseStatus")
+
+                if isinstance(result, str):
+                    result = result.lower()
+
+                    if result in ("success", "succeeded", "completed", "complete"):
+                        return True
+
+                    if result in ("failure", "failed", "error", "rejected"):
+                        return False
+
+            except Exception as err:
+                last_error = err
+
             r = self._get_commands_statuses(vin)
             if id in r:
                 return r[id]
 
-        raise Exception(f"unable to obtain execution status: timed out (id {id})")
+        raise Exception(
+            f"unable to obtain execution status: timed out "
+            f"(id {id}; last_error={last_error})"
+        )
 
     def get_remote_operation_status(self, vin: str, correlation_id: str) -> dict:
         """Get the status of a remote operation by its correlation ID"""

--- a/py_uconnect/command.py
+++ b/py_uconnect/command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 
@@ -6,6 +8,7 @@ class Command:
     name: str
     url: str = "remote"
     api_version: str = "v1"
+    fallback: Command | None = None
 
     def __repr__(self):
         return self.name
@@ -29,10 +32,25 @@ COMMAND_LIFTGATE_UNLOCK = Command(name="ROLIFTGATEUNLOCK", api_version="v2")
 COMMAND_LIFTGATE_LOCK = Command(name="ROLIFTGATELOCK", api_version="v2")
 COMMAND_CABIN_VENTILATION = Command(name="ACV", api_version="v2")
 COMMAND_HVAC_TARGET_TEMP = Command(name="ROHVACTMP", api_version="v2")
-COMMAND_CHARGE = Command(name="CNOW", url="ev/chargenow")
-COMMAND_CHARGE_V4 = Command(name="CNOW2", url="ev/chargenow", api_version="v4")
-COMMAND_DEEP_REFRESH = Command(name="DEEPREFRESH", url="ev")
+
 COMMAND_DEEP_REFRESH_V2 = Command(name="DEEPREFRESH2", url="ev", api_version="v2")
+COMMAND_DEEP_REFRESH = Command(
+    name="DEEPREFRESH",
+    url="ev",
+    fallback=COMMAND_DEEP_REFRESH_V2,
+)
+
+COMMAND_CHARGE_V4 = Command(
+    name="START_CHARGE",
+    url="ev/chargenow",
+    api_version="v4",
+)
+COMMAND_CHARGE = Command(
+    name="CNOW",
+    url="ev/chargenow",
+    fallback=COMMAND_CHARGE_V4,
+)
+
 COMMAND_REFRESH_LOCATION = Command(name="VF", url="location")
 
 COMMANDS = [


### PR DESCRIPTION
## Summary

Fixes EV remote command failures where Deep Refresh and Charge Now can return HTTP 403 on the legacy command endpoints.

This updates the command definitions and command execution flow to match newer Jeep app behavior:

- Adds optional fallback support to `Command`
- Retries `DEEPREFRESH` with `DEEPREFRESH2` on the v2 EV endpoint when the legacy v1 request returns 403
- Updates v4 Charge Now to use `START_CHARGE`
- Retries legacy `CNOW` with the v4 Charge Now command when the legacy request returns 403
- Improves command verification by checking remote operation status before falling back to notification polling

## Why

Users in hass-uconnect issue #96 report that Deep Refresh triggers the official app notification but Home Assistant receives a 403 from:

`/v1/accounts/{account}/vehicles/{vin}/ev`

The Jeep app 1.99.7 XAPK includes newer EV command paths and command names, including `DEEPREFRESH2`, `/v2/accounts/%s/vehicles/%s/ev/`, `/v4/accounts/%s/vehicles/%s/ev/chargenow/`, and `START_CHARGE`.

## Testing

- Verified command fallback behavior is only used on HTTP 403
- Existing commands without a fallback continue to raise the original HTTP error
- Fallback commands reuse the same PIN auth token
- Command status polling still supports the existing notification-based flow as a fallback

Fixes hass-uconnect/hass-uconnect#96