### PR TITLE
Load older vehicles with partial status data

### DIFF
--- a/py_uconnect/api.py
+++ b/py_uconnect/api.py
@@ -249,7 +249,13 @@ class API:
         return r["vehicles"]
 
     def get_vehicle(self, vin: str) -> dict:
-        """Gets a more detailed info abount a vehicle with a given VIN"""
+        """Gets detailed info about a vehicle with a given VIN.
+
+        Some older vehicles can be returned by the account vehicle list but fail
+        the newer v3 status endpoint with 502. Try v4 next, then allow the
+        vehicle to load with partial data so remote/status and location can
+        still populate what is available.
+        """
 
         if self.dev_mode:
             with open(f"test_vehicle_{vin}.json") as f:
@@ -257,19 +263,45 @@ class API:
 
         self._refresh_token_if_needed()
 
-        r = self.sess.request(
-            method="GET",
-            url=self.brand.api.url + f"/v3/accounts/{self.uid}/vehicles/{vin}/status",
-            headers=self._default_aws_headers(self.brand.api.key)
-            | {"content-type": "application/json"},
-            auth=self.aws_auth,
+        last_error = None
+
+        for api_version in ("v3", "v4"):
+            try:
+                r = self.sess.request(
+                    method="GET",
+                    url=self.brand.api.url
+                    + f"/{api_version}/accounts/{self.uid}/vehicles/{vin}/status",
+                    headers=self._default_aws_headers(self.brand.api.key)
+                    | {"content-type": "application/json"},
+                    auth=self.aws_auth,
+                )
+
+                r.raise_for_status()
+                _LOGGER.debug(f"get_vehicle ({vin}, {api_version}): {r.text}")
+                return r.json()
+
+            except requests.exceptions.HTTPError as err:
+                last_error = err
+
+                status_code = err.response.status_code if err.response is not None else None
+
+                if status_code not in (400, 404, 502):
+                    raise
+
+                _LOGGER.warning(
+                    "Vehicle %s status endpoint %s failed with HTTP %s; trying fallback",
+                    vin,
+                    api_version,
+                    status_code,
+                )
+
+        _LOGGER.warning(
+            "Vehicle %s does not support v3/v4 detailed status; loading partial vehicle data: %s",
+            vin,
+            last_error,
         )
 
-        r.raise_for_status()
-        _LOGGER.debug(f"get_vehicle ({vin}): {r.text}")
-        r = r.json()
-
-        return r
+        return {}
 
     def get_vehicle_status(self, vin: str) -> dict:
         """Loads another part of status of a vehicle with a given VIN"""

--- a/py_uconnect/api.py
+++ b/py_uconnect/api.py
@@ -252,9 +252,9 @@ class API:
         """Gets detailed info about a vehicle with a given VIN.
 
         Some older vehicles can be returned by the account vehicle list but fail
-        the newer v3 status endpoint with 502. Try v4 next, then allow the
-        vehicle to load with partial data so remote/status and location can
-        still populate what is available.
+        newer detailed status endpoints. Try v3, then v4, then allow the vehicle
+        to load with partial data so remote/status and location can still
+        populate what is available.
         """
 
         if self.dev_mode:
@@ -264,13 +264,14 @@ class API:
         self._refresh_token_if_needed()
 
         last_error = None
+        api_versions = ("v3", "v4")
 
-        for api_version in ("v3", "v4"):
+        for index, api_version in enumerate(api_versions):
             try:
                 r = self.sess.request(
                     method="GET",
                     url=self.brand.api.url
-                    + f"/{api_version}/accounts/{self.uid}/vehicles/{vin}/status",
+                    + f"/{api_version}/accounts/{self.uid}/vehicles/{vin}/status/",
                     headers=self._default_aws_headers(self.brand.api.key)
                     | {"content-type": "application/json"},
                     auth=self.aws_auth,
@@ -282,18 +283,25 @@ class API:
 
             except requests.exceptions.HTTPError as err:
                 last_error = err
-
                 status_code = err.response.status_code if err.response is not None else None
 
                 if status_code not in (400, 404, 502):
                     raise
 
-                _LOGGER.warning(
-                    "Vehicle %s status endpoint %s failed with HTTP %s; trying fallback",
-                    vin,
-                    api_version,
-                    status_code,
-                )
+                if index < len(api_versions) - 1:
+                    _LOGGER.warning(
+                        "Vehicle %s status endpoint %s failed with HTTP %s; trying next status endpoint",
+                        vin,
+                        api_version,
+                        status_code,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Vehicle %s status endpoint %s failed with HTTP %s; no detailed status endpoint remains",
+                        vin,
+                        api_version,
+                        status_code,
+                    )
 
         _LOGGER.warning(
             "Vehicle %s does not support v3/v4 detailed status; loading partial vehicle data: %s",


### PR DESCRIPTION
## Summary

Allows older or partially supported vehicles to load when newer detailed status endpoints are unavailable.

Some vehicles can be returned by the account vehicle list but fail the detailed status request at:

`/v3/accounts/{account}/vehicles/{vin}/status/`

In hass-uconnect/hass-uconnect#93, a 2014 Dodge Charger appears on the user’s account but causes the detailed status request to return `502 Bad Gateway`. Since that error happens during the required vehicle refresh path, it prevents the integration from loading even though other vehicles on the account work.

This change updates vehicle loading to:

- Try the existing v3 detailed status endpoint first
- Fall back to the v4 detailed status endpoint
- Treat expected compatibility errors like `400`, `404`, and `502` as partial-data cases
- Return an empty payload when detailed status is unavailable so the vehicle can still be created from `list_vehicles()` data
- Preserve unexpected HTTP errors by re-raising them

## Why

Older vehicles may still be visible on a Stellantis/Uconnect account but may not support the newer status APIs used for detailed vehicle data. Instead of failing the entire refresh, the library should allow those vehicles to load with whatever data is available.

This should let affected vehicles appear in Home Assistant with partial data, while still allowing location, remote status, and supported services to populate if those endpoints work.

## Notes

This does not guarantee full sensor support for older vehicles. It only prevents detailed status endpoint failures from blocking the vehicle from loading.

Related to hass-uconnect/hass-uconnect#93