### PR TITLE
Catch HTTPError in _poll_correlation_id so 404 status endpoint falls back to notifications

### DIFF
--- a/py_uconnect/client.py
+++ b/py_uconnect/client.py
@@ -446,7 +446,12 @@ class Client:
                     if result in ("failure", "failed", "error", "rejected"):
                         return False
 
-            except (ConnectionError, TimeoutError, ValueError) as err:
+            except (ConnectionError, TimeoutError, ValueError, HTTPError) as err:
+                # Some brands/regions return 404 for the remote-operation status
+                # endpoint even though the command itself succeeds (see issue #105).
+                # Don't abort the poll on the HTTP error: fall through to the
+                # notifications-based fallback below, which reports the status via
+                # a working endpoint.
                 last_error = err
 
             r = self._get_commands_statuses(vin)


### PR DESCRIPTION
## Problem

For some brands/regions (Fiat 500e, Jeep Avenger, ...) the remote-operation status endpoint

```
GET /v1/accounts/{uid}/vehicles/{vin}/remote/{correlation_id}/status/
```

returns **HTTP 404** even though the command itself was accepted and executes successfully. This surfaces in Home Assistant (hass-uconnect) as a 500 on `charge_now`, `deep_refresh` and `refresh_location`, while the action actually works.

See hass-uconnect/hass-uconnect#105 ("Deep refresh or Location refresh return 404 but work").

## Root cause

`_poll_correlation_id` already has a notifications-based fallback (`_get_commands_statuses`) right after the `try`/`except`, precisely for the case where the status endpoint can't be read. But its `except` tuple only catches `(ConnectionError, TimeoutError, ValueError)`, **not** `requests.exceptions.HTTPError`. So the 404 raised by `get_remote_operation_status` propagates out of the loop and aborts the poll instead of degrading to the fallback.

(`HTTPError` is already imported at the top of `client.py`, it just wasn't in the tuple.)

## Fix

Add `HTTPError` to the caught exceptions so a non-2xx status response (404 in particular) falls through to the working notifications fallback, which then reports the command status. Minimal, no behaviour change for brands where the status endpoint works.

Fixes hass-uconnect/hass-uconnect#105.