### PR TITLE
Add EMEA charge-schedule support (read from v3 status, write via v2 CPPLUS)

### DIFF
--- a/py_uconnect/api.py
+++ b/py_uconnect/api.py
@@ -756,6 +756,47 @@ class API:
 
         return r["correlationId"]
 
+    def set_charge_schedule_emea(self, vin: str, schedules: list[dict]):
+        """Sets EV charge schedules on EMEA vehicles.
+
+        Unlike ``set_charge_schedule`` (which POSTs to ``/v4/.../ev/schedule/``
+        and fails with HTTP 500 on EMEA cars such as the Fiat New 500e), this
+        posts the full slot list to ``/v2/.../ev/schedule/`` wrapped in a
+        ``CPPLUS`` command envelope. Confirmed working via live test on an
+        EMEA 500e (soldRegion=EMEA, sdp=IGNITE).
+
+        ``schedules`` must contain *all* slots (typically three); the backend
+        replaces the entire list on every write.
+        """
+
+        pin_auth = self._pin_auth()
+
+        data = {
+            "command": "CPPLUS",
+            "pinAuth": pin_auth,
+            "schedules": schedules,
+        }
+
+        r = self.sess.request(
+            method="POST",
+            url=self.brand.api.url
+            + f"/v2/accounts/{self.uid}/vehicles/{vin}/ev/schedule/",
+            headers=self._default_aws_headers(self.brand.api.key)
+            | {"content-type": "application/json"},
+            auth=self.aws_auth,
+            json=data,
+        )
+
+        r.raise_for_status()
+        _LOGGER.debug(f"set_charge_schedule_emea ({vin}): {r.text}")
+        r = r.json()
+
+        if "correlationId" not in r:
+            error = r.get("debugMsg", "unknown error")
+            raise Exception(f"set charge schedule (emea) failed: {error} ({r})")
+
+        return r["correlationId"]
+
     def set_charging_level(
         self, vin: str, level: ChargingLevel, max_soc: str | None = None
     ):

--- a/py_uconnect/client.py
+++ b/py_uconnect/client.py
@@ -65,6 +65,14 @@ CHARGING_LEVELS = {
     "LEVEL_1": 1,
     "LEVEL_2": 2,
     "LEVEL_3": 3,
+    "LEVEL_4": 4,
+    "LEVEL_5": 5,
+    # EMEA firmware reports the preference as LEVEL_ONE..LEVEL_FIVE
+    "LEVEL_ONE": 1,
+    "LEVEL_TWO": 2,
+    "LEVEL_THREE": 3,
+    "LEVEL_FOUR": 4,
+    "LEVEL_FIVE": 5,
 }
 
 
@@ -80,6 +88,83 @@ class Location:
 
     def __repr__(self):
         return f"lat: {self.latitude}, lon: {self.longitude} (updated {self.updated})"
+
+
+@dataclass_json
+@dataclass
+class ScheduledDays:
+    monday: bool = False
+    tuesday: bool = False
+    wednesday: bool = False
+    thursday: bool = False
+    friday: bool = False
+    saturday: bool = False
+    sunday: bool = False
+
+
+@dataclass_json
+@dataclass
+class ChargeSchedule:
+    """A single EV charge schedule slot.
+
+    EMEA vehicles (e.g. Fiat New 500e) expose up to three of these inline in
+    the v3 vehicle status under ``evInfo.schedules``. The North-American
+    ``/v4/.../ev/schedule/`` endpoint is not used by these cars and returns
+    HTTP 500. Writing is done via ``Client.set_charge_schedule_emea`` which
+    POSTs the full list back to ``/v2/.../ev/schedule/``.
+    """
+
+    enable: bool = False
+    start_time: str = "00:00"
+    end_time: str = "00:00"
+    days: ScheduledDays = field(default_factory=ScheduledDays)
+    charge_to_full: bool = False
+    cabin_priority: bool = False
+    repeat_schedule: bool = True
+    schedule_type: str = "CHARGE"
+
+    @staticmethod
+    def from_api(d: dict) -> "ChargeSchedule":
+        days = d.get("scheduledDays") or {}
+        return ChargeSchedule(
+            enable=bool(d.get("enableScheduleType", False)),
+            start_time=d.get("startTime", "00:00"),
+            end_time=d.get("endTime", "00:00"),
+            days=ScheduledDays(
+                monday=bool(days.get("monday", False)),
+                tuesday=bool(days.get("tuesday", False)),
+                wednesday=bool(days.get("wednesday", False)),
+                thursday=bool(days.get("thursday", False)),
+                friday=bool(days.get("friday", False)),
+                saturday=bool(days.get("saturday", False)),
+                sunday=bool(days.get("sunday", False)),
+            ),
+            charge_to_full=bool(d.get("chargeToFull", False)),
+            cabin_priority=bool(d.get("cabinPriority", False)),
+            repeat_schedule=bool(d.get("repeatSchedule", True)),
+            schedule_type=d.get("scheduleType", "CHARGE"),
+        )
+
+    def to_api(self) -> dict:
+        """Serialise back into the exact shape the backend expects."""
+        return {
+            "chargeToFull": self.charge_to_full,
+            "scheduleType": self.schedule_type,
+            "enableScheduleType": self.enable,
+            "scheduledDays": {
+                "sunday": self.days.sunday,
+                "saturday": self.days.saturday,
+                "tuesday": self.days.tuesday,
+                "wednesday": self.days.wednesday,
+                "thursday": self.days.thursday,
+                "friday": self.days.friday,
+                "monday": self.days.monday,
+            },
+            "startTime": self.start_time,
+            "endTime": self.end_time,
+            "cabinPriority": self.cabin_priority,
+            "repeatSchedule": self.repeat_schedule,
+        }
 
 
 @dataclass_json
@@ -124,13 +209,17 @@ class Vehicle:
     ev_running: bool | None = None
     charging: bool | None = None
     charging_level: int | None = None
-    charging_level_preference: str | None = None
+    charging_level_preference: int | None = None
     state_of_charge: float | None = None
     time_to_fully_charge_l3: int | None = None
     time_to_fully_charge_l2: int | None = None
     time_to_fully_charge_l1: int | None = None
     ev_head_seat: bool | None = None
     ev_cabin_cond: bool | None = None
+    # EV charge schedules (EMEA vehicles expose these inline in v3 status
+    # under evInfo.schedules; the /v4/.../ev/schedule/ endpoint returns 500
+    # for these cars). Read-only view; write via set_charge_schedule_emea.
+    charge_schedules: list[ChargeSchedule] = field(default_factory=list)
 
     # Wheels
     wheel_front_left_pressure: float | None = None
@@ -176,9 +265,14 @@ def _update_vehicle(v: Vehicle, p: dict) -> Vehicle:
     v.battery_state_of_charge = sg(vi, "batteryInfo", "batteryStateOfCharge")
     v.charging = sg_eq(batt, "CHARGING", "chargingStatus")
     v.charging_level = CHARGING_LEVELS.get(sg(batt, "chargingLevel"), None)
-    v.charging_level_preference = sg(ev, "chargePowerPreference")
-    if v.charging_level_preference == "NOT_USED_VALUE":
+    # chargePowerPreference is reported as a word-form string (EMEA:
+    # LEVEL_ONE..LEVEL_FIVE; NA: LEVEL_1..LEVEL_5). Map it to the same 1..5
+    # integer scale as charging_level for consistency (README shows int 5).
+    _pref_raw = sg(ev, "chargePowerPreference")
+    if _pref_raw in (None, "NOT_USED_VALUE"):
         v.charging_level_preference = None
+    else:
+        v.charging_level_preference = CHARGING_LEVELS.get(_pref_raw, None)
 
     v.plugged_in = sg(batt, "plugInStatus")
     v.state_of_charge = sg(batt, "stateOfCharge")
@@ -208,6 +302,13 @@ def _update_vehicle(v: Vehicle, p: dict) -> Vehicle:
     csai = sg(ev, "chargeScheduleAdditionalInfo")
     v.ev_head_seat = sg(csai, "headSeat")
     v.ev_cabin_cond = sg(csai, "cabinCond")
+
+    # EMEA charge schedules live inline in the v3 status. Newer NA firmware
+    # instead exposes evInfo.chargeSchedules (different layout) and the v4
+    # endpoint; we only parse the inline EMEA "schedules" list here.
+    sched_raw = sg(ev, "schedules")
+    if isinstance(sched_raw, list):
+        v.charge_schedules = [ChargeSchedule.from_api(x) for x in sched_raw]
 
     v.time_to_fully_charge_l3 = sg(batt, "timeToFullyChargeL3")
     v.time_to_fully_charge_l2 = sg(batt, "timeToFullyChargeL2")
@@ -546,6 +647,29 @@ class Client:
 
         id = self.api.set_charge_schedule(vin, schedule)
         return self._poll_correlation_id(vin, id)
+
+    def set_charge_schedule_emea(
+        self, vin: str, schedules: list[ChargeSchedule], verify: bool = False
+    ):
+        """Set EV charge schedules for EMEA vehicles.
+
+        The backend replaces the *entire* schedule list on every write, so the
+        full set of slots must always be sent — sending a single slot silently
+        resets the others to their defaults. Callers should therefore take the
+        vehicle's current ``charge_schedules``, modify the slot(s) they care
+        about, and pass the whole list back in.
+
+        Uses the ``CPPLUS`` command against ``/v2/.../ev/schedule/`` (confirmed
+        working on Fiat New 500e / EMEA, where the NA ``/v4`` endpoint returns
+        HTTP 500). Returns the correlation id, or the poll result if
+        ``verify`` is True.
+        """
+
+        payload = [s.to_api() for s in schedules]
+        id = self.api.set_charge_schedule_emea(vin, payload)
+        if verify:
+            return self._poll_correlation_id(vin, id)
+        return id
 
     def set_charging_level(
         self, vin: str, level: ChargingLevel, max_soc: str | None = None


### PR DESCRIPTION
## Summary

EMEA EVs such as the Fiat New 500e do **not** use the North-American
`/v4/accounts/{uid}/vehicles/{vin}/ev/schedule/` endpoint. That endpoint
returns **HTTP 500** for these cars. Instead:

- **Read:** the (up to three) charge schedules are already present inline in
  the v3 vehicle status under `evInfo.schedules`. No extra request is needed.
- **Write:** schedules are set with a `POST /v2/.../ev/schedule/` carrying a
  `CPPLUS` command envelope (`{command, pinAuth, schedules[]}`).

This PR adds a typed representation of those schedules to `Vehicle`, parses
them from the v3 status, and adds read-modify-write support via a new
`Client.set_charge_schedule_emea()` / `API.set_charge_schedule_emea()`.

Everything is **additive** - no existing behaviour changes, the NA
`set_charge_schedule` (v4) path is untouched.

## Confirmed working

Verified live against a 2022 Fiat New 500e (soldRegion=EMEA, sdp=IGNITE,
market=DE, service CPPLUS serviceEnabled=true):

    GET  /v4/.../ev/schedule/  -> HTTP 500 Internal Server Error   (NA endpoint, unusable)
    POST /v2/.../ev/schedule/  -> HTTP 200
         {"command":"CPPLUS","correlationId":"...","responseStatus":"pending","asyncRespTimeout":2}

Setting slot 1 to "Mon-Fri 01:00-05:00" was reflected both in the subsequent
v3 status read and in the official Fiat app; disabling it again worked the
same way. `ChargeSchedule.to_api()` reproduces the confirmed 200 payload
byte-for-byte (verified in a unit test against the real status payload).

Fixes the read/write gap reported downstream in hass-uconnect#110
(Fiat 500e EU/EMEA schedule charging).

## Changes

### client.py
- New `@dataclass_json` classes `ScheduledDays` and `ChargeSchedule` with
  `from_api()` / `to_api()` converters (API <-> snake_case).
- New field `Vehicle.charge_schedules: list[ChargeSchedule]`.
- `_update_vehicle()` now parses `evInfo.schedules` into that field.
- `Client.set_charge_schedule_emea(vin, schedules, verify=False)` - takes the
  full slot list, serialises, POSTs, optionally polls the correlation id.
- `CHARGING_LEVELS` extended with `LEVEL_4`/`LEVEL_5` and the EMEA word-form
  keys `LEVEL_ONE..LEVEL_FIVE`.
- `charging_level_preference` is now mapped through `CHARGING_LEVELS` to an
  **int (1..5)** instead of being left as the raw string, matching the README
  example (`"charging_level_preference": 5`) and `charging_level`. Type hint
  changed `str -> int`.

### api.py
- `API.set_charge_schedule_emea(vin, schedules)` - the
  `POST /v2/.../ev/schedule/` with the `CPPLUS` envelope. Raises on missing
  `correlationId`, mirroring the existing `set_charge_schedule`.

## Important behavioural note (documented in the docstring)

The backend **replaces the entire schedule list** on every write. Sending a
single slot silently resets the others to defaults. Callers must therefore
read `vehicle.charge_schedules`, modify the slot(s) they need, and pass the
whole list back - `set_charge_schedule_emea` is designed around exactly this
read-modify-write pattern.

## Possible breaking change to flag for the maintainer
`charging_level_preference` changes type from `str` ("LEVEL_FIVE") to
`int` (5). This matches the documented README output and `charging_level`,
but any downstream consumer comparing the raw string would need updating.
Happy to keep it as a string if you prefer - just say the word.

## Not included / out of scope
- Trip history: on this vehicle `ECOCOACHING20`/`TRIPREPORT` are
  serviceEnabled=false, the eco-coaching endpoints return nothing usable.
- Auto-detecting NA vs EMEA: left to the caller for now (the two write paths
  coexist). A follow-up could switch on `soldRegion`.