### PR TITLE
Replaced boto3 with botocore

### DIFF
--- a/py_uconnect/api.py
+++ b/py_uconnect/api.py
@@ -1,7 +1,6 @@
 import requests
 import uuid
 import json
-import boto3
 import base64
 import logging
 import http.client as http_client
@@ -114,7 +113,11 @@ class API:
         """Logs into the Uconnect and caches the auth tokens"""
 
         if self.cognito_client is None:
-            self.cognito_client = boto3.client("cognito-identity", self.brand.region)
+            self.cognito_client = get_session().create_client(
+                "cognito-identity",
+                region_name=self.brand.region,
+                config=Config(signature_version=UNSIGNED),
+            )
 
         r = self.sess.request(
             method="GET",

--- a/py_uconnect/api.py
+++ b/py_uconnect/api.py
@@ -14,6 +14,10 @@ from requests_auth_aws_sigv4 import AWSSigV4
 from .command import Command
 from .brands import Brand
 
+from botocore.session import get_session
+from botocore.config import Config
+from botocore import UNSIGNED
+
 _LOGGER = logging.getLogger("py_uconnect")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-botocore>=1.36.0
+botocore>=1.36.0,<1.37.2
 requests>=2.32.3
 requests-auth-aws-sigv4>=0.7
 dataclasses_json>=0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.35.96
+botocore>=1.36.0
 requests>=2.32.3
 requests-auth-aws-sigv4>=0.7
 dataclasses_json>=0.6.7

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     description="Python API Client for FCA/Stellantis cars",
     install_requires=[
-        "botocore>=1.36.0",
+        "botocore>=1.36.0,<1.37.1",
         "requests>=2.32.3",
         "requests-auth-aws-sigv4>=0.7",
         "dataclasses_json>=0.6.7",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     description="Python API Client for FCA/Stellantis cars",
     install_requires=[
-        "botocore>=1.36.0,<1.37.1",
+        "botocore>=1.36.0,<1.37.2",
         "requests>=2.32.3",
         "requests-auth-aws-sigv4>=0.7",
         "dataclasses_json>=0.6.7",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     description="Python API Client for FCA/Stellantis cars",
     install_requires=[
-        "boto3>=1.35.96",
+        "botocore>=1.36.0",
         "requests>=2.32.3",
         "requests-auth-aws-sigv4>=0.7",
         "dataclasses_json>=0.6.7",
@@ -44,6 +44,6 @@ setup(
     name="py-uconnect",
     packages=find_packages(include=["py_uconnect", "py_uconnect.*"]),
     url="https://github.com/hass-uconnect/py-uconnect",
-    version="0.4.3",
+    version="0.4.4.dev0",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     name="py-uconnect",
     packages=find_packages(include=["py_uconnect", "py_uconnect.*"]),
     url="https://github.com/hass-uconnect/py-uconnect",
-    version="0.4.4.dev0",
+    version="0.4.4",
     zip_safe=False,
 )


### PR DESCRIPTION
The uncapped version ceiling for the boto3 requirement was causing HAOS to update botocore past 1.37.1, breaking other integrations. Switched from boto3 to botocore and capped the version to 1.37.1.